### PR TITLE
Add reviewdog status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # agilepathway-template
 
+[![reviewdog](../../workflows/reviewdog/badge.svg)](../../actions?query=workflow%3Areviewdog+event%3Apush+branch%3Amaster)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Template repository with generic Codespaces configuration, YAML linting etc


### PR DESCRIPTION
Using [relative links for this GitHub Action status badge][1], so that
when we generate new repositories from this GitHub template repository
the links will still work.

[1]: https://stackoverflow.com/a/60274975