### PR TITLE
Add misspell check via reviewdog

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -41,3 +41,13 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
+
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: reviewdog/action-misspell@v1.7
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-check


### PR DESCRIPTION
https://github.com/reviewdog/action-misspell

https://github.com/client9/misspell

NB if in the future we add golangci-lint linting for go, for example,
then we will include misspell checking there too.  We also want
misspell to check markdown files too though, so we'll still need this
separate check as well.

There will be no harm in having any spelling errors being reported more
than once.