### PR TITLE
Extend the default GitHub Codespaces configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/vscode/devcontainers/universal:linux

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,10 @@
+# Agile Pathway Codespaces
+
+Extends [the Ubuntu-based default, large, multi-language universal container for GitHub Codespaces](https://github.com/microsoft/vscode-dev-containers/blob/master/containers/codespaces-linux/README.md)
+
+You can develop entirely in the cloud using Codespaces, an integrated development environment (IDE) on GitHub.
+
+Modify the `devcontainer.json` and `Dockerfile` files to [customise the Codespace configuration](https://docs.github.com/en/github/developing-online-with-codespaces/configuring-codespaces-for-your-project#creating-a-custom-codespace-configuration).
+
+[GitHub Codespaces documentation](https://docs.github.com/en/github/developing-online-with-codespaces)
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+	"name": "GitHub Codespaces (Default)",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.useGoProxyToCheckForToolUpdates": false,
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"go.goroot": "/usr/local/go",
+		"go.toolsGopath": "/go/bin",
+		"python.pythonPath": "/opt/python/latest/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"lldb.executable": "/usr/bin/lldb",
+		"files.watcherExclude": {
+			"**/target/**": true
+		}
+	},
+	"remoteUser": "codespace",
+	"overrideCommand": false,
+	"workspaceMount": "source=${localWorkspaceFolder},target=/home/codespace/workspace,type=bind,consistency=cached",
+	"workspaceFolder": "/home/codespace/workspace",
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--privileged", "--init" ],
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"GitHub.vscode-pull-request-github"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// "oryx build" will automatically install your dependencies and attempt to build your project
+	"postCreateCommand": "oryx build -p virtualenv_name=.venv || echo 'Could not auto-build. Skipping.'"
+}


### PR DESCRIPTION
This commit wires in the configuration files for [GitHub Codespaces][1],
extending the [default Codespaces configuration][2], thereby allowing
the [Codespaces configuration to be customised][3] as we wish in future
commits.

[1]: https://docs.github.com/en/github/developing-online-with-codespaces
[2]: https://github.com/microsoft/vscode-dev-containers/blob/master/containers/codespaces-linux/README.md
[3]: https://docs.github.com/en/github/developing-online-with-codespaces/configuring-codespaces-for-your-project#creating-a-custom-codespace-configuration