### PR TITLE
Remove placeholder script

### DIFF
--- a/scripts/example.sh
+++ b/scripts/example.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# This is just a placeholder file, to ensure that the shellcheck GitHub Action does not fail
-# saying there are no files found (for it to check).
-# So this file can be removed as soon as the repo has at least one other shell script.


### PR DESCRIPTION
The placeholder script was needed because the GitHub Action shellcheck
linting check needs at least one shell script to be present in the repo.
We now have another shell script (to install hadolint on the
devcontainer), so the placeholder script is no longer necessary.