### PR TITLE
Add ability to install Gauge on devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,7 @@ COPY scripts/* /tmp/scripts/
 USER root
 
 RUN /tmp/scripts/install-hadolint.sh \
+    # && /tmp/scripts/install-gauge.sh \
     && rm -rf /tmp/scripts
 
 USER codespace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,10 @@
 		"lldb.executable": "/usr/bin/lldb",
 		"files.watcherExclude": {
 			"**/target/**": true
+		},
+		"files.associations": {
+			"*.spec": "gauge",
+			"*.cpt": "gauge"
 		}
 	},
 	"remoteUser": "codespace",
@@ -50,7 +54,7 @@
 		"redhat.vscode-yaml",
 		"davidanson.vscode-markdownlint",
 		"timonwong.shellcheck",
-		"exiasr.hadolint"
+		"exiasr.hadolint",
 		// "ms-python.python",
 		// "ms-python.vscode-pylance",
 		// "getgauge.gauge",

--- a/.devcontainer/scripts/install-gauge.sh
+++ b/.devcontainer/scripts/install-gauge.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+GAUGE_VERSION=v1.1.7
+TRUNCATED_GAUGE_VERSION="${GAUGE_VERSION:1}"
+
+wget https://github.com/getgauge/gauge/releases/download/$GAUGE_VERSION/gauge-$TRUNCATED_GAUGE_VERSION-linux.x86_64.zip
+unzip -o gauge-$TRUNCATED_GAUGE_VERSION-linux.x86_64.zip -d /usr/local/bin
+su codespace -c "gauge install html-report"
+# su codespace -c "gauge install python"
+# add more plugins here as required


### PR DESCRIPTION
Not every project will need Gauge, so we have left the actual
installation of Gauge on the devcontainer commented out by default.