### PR TITLE
Run on ubuntu-latest

### DIFF
--- a/.github/DEPENDENCIES.md
+++ b/.github/DEPENDENCIES.md
@@ -14,11 +14,3 @@ for us to merge).
 Dependabot automatically updates our:
 
 - [GitHub Actions (non-Docker dependencies only, for now)](https://github.blog/2020-06-25-dependabot-now-updates-your-actions-workflows/)
-
-## Ubuntu version
-
-GitHub Actions supports Ubuntu LTS versions only.  [Ubuntu releases a new LTS version every second year in
-April](https://wiki.ubuntu.com/Releases).  In 2020 the GitHub Actions team [supported the new version by
- mid-June](https://github.com/actions/virtual-environments/issues/228#issuecomment-644065532), so the owner of the repo
-has a reminder in their calendar every 2 years (on 15 July as that should have given GitHub sufficient time to update
-to the new LTS version) to update the GitHub Actions on this repo with the new version.

--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -17,7 +17,7 @@ jobs:
       (github.actor!= 'dependabot[bot]') &&
       (contains(github.head_ref, 'dependabot/github_actions/') == false)
     name: Check commit message style
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check
         uses: mristin/opinionated-commit-message@v2.3.2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
 jobs:
   yamllint:
     name: runner / yamllint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
       - name: yamllint
@@ -17,7 +17,7 @@ jobs:
 
   markdownlint:
     name: runner / markdownlint ${{ matrix.pattern }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # Make sure we lint all markdown files including in hidden directories
@@ -34,7 +34,7 @@ jobs:
 
   shellcheck:
     name: runner / shellcheck
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
       - name: shellcheck
@@ -48,7 +48,7 @@ jobs:
 
   hadolint:
     name: runner / hadolint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2.4.0
@@ -60,7 +60,7 @@ jobs:
 
   misspell:
     name: runner / misspell
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: reviewdog/action-misspell@v1.12.2
@@ -70,7 +70,7 @@ jobs:
 
   languagetool:
     name: runner / languagetool
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: reviewdog/action-languagetool@v1.9.0
@@ -86,7 +86,7 @@ jobs:
 
   golangci-lint:
     name: runner / golangci-lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: reviewdog/action-golangci-lint@v2.0.3


### PR DESCRIPTION
This means we no longer have
to update the ubuntu version. If
this ever causes a problem we
can pin the ubuntu version again
if we need to.