### PR TITLE
Do no pin commit checker version

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v2.3.2
+        uses: mristin/opinionated-commit-message@master
         with:
           allow-one-liners: "true"
           additional-verbs: "customise, lint"


### PR DESCRIPTION
This is part of a wider initiative to
reduce the time spent updating
dependency updates.  The commit
checker will never affect production
so it is not a risk not to pin the version.